### PR TITLE
Update ReaderMainToolbar.m

### DIFF
--- a/src/ios/ReaderFramework/ReaderMainToolbar.m
+++ b/src/ios/ReaderFramework/ReaderMainToolbar.m
@@ -183,7 +183,7 @@
             }
         }
         
-        if ((document.canPrint == YES) && [[ReaderConstants sharedReaderConstants] enableShare] && (document.password == nil)) // Document print enabled
+        if ((document.canPrint == YES) && [[ReaderConstants sharedReaderConstants] enableShare] && ([document.password isEqual:[NSNull null]])) // Document print enabled
         {
             Class printInteractionController = NSClassFromString(@"UIPrintInteractionController");
             


### PR DESCRIPTION
We had an issue with the print button not showing up in the reader with a pdf that didn't have a password. The check for password==nil was not valid and had to change it to [document.password isEqual:[NSNull null]] to make it work. Not sure which branch so I'm submitting a pull request for both branches.